### PR TITLE
Add newcomers-alert workflow

### DIFF
--- a/.github/workflows/newcomers-alert.yml
+++ b/.github/workflows/newcomers-alert.yml
@@ -1,0 +1,16 @@
+name: Newcomers Alert
+on:
+  issues:
+    types: [labeled]
+jobs:
+  good-first-issue-notify:
+    if: github.event.label.name == 'good first issue' || github.event.label.name == 'first-timers-only' 
+    name: Notify Slack for new good-first-issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify slack
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: pullreminders/slack-action@master
+        with:
+          args: '{\"channel\":\"C019426UBNY\",\"text\":\"A good first issue label was just added to ${{github.event.issue.html_url}}.\"}'


### PR DESCRIPTION
Signed-off-by: Jerod Culpepper cpepper96@gmail.com

**Description**

Added newcomers-alert workflow to the Nighthawk repo.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
